### PR TITLE
1.1.0 New features and bugfix

### DIFF
--- a/docs/masks.md
+++ b/docs/masks.md
@@ -29,6 +29,9 @@ title: Masks
     options:  
       show_root_heading: false
 
+::: maskmypy.street_k
+    options:  
+      show_root_heading: false
 --- 
 
 ## Location Swapping

--- a/maskmypy/__init__.py
+++ b/maskmypy/__init__.py
@@ -1,5 +1,5 @@
 from . import analysis
 from .atlas import Atlas
-from .masks import donut, locationswap, street, voronoi
+from .masks import donut, locationswap, street, street_k, voronoi
 
 name = "maskmypy"

--- a/maskmypy/analysis.py
+++ b/maskmypy/analysis.py
@@ -575,7 +575,7 @@ def _estimate_k(
         .groupby("_index_2")[pop_col_adjusted]
         .sum()
         .apply(floor)
-    ) - 1
+    )
     return candidate_gdf
 
 
@@ -590,6 +590,7 @@ def _calculate_k(
         sjoin(address_gdf, candidate_gdf_tmp, how="left", rsuffix="candidate")
         .groupby("index_candidate")
         .size()
+        + 1
     )
-    candidate_gdf.fillna({"k_anonymity": 0}, inplace=True)
+    candidate_gdf.fillna({"k_anonymity": 1}, inplace=True)
     return candidate_gdf

--- a/maskmypy/atlas.py
+++ b/maskmypy/atlas.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-import pprint
 import tracemalloc
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/maskmypy/masks/__init__.py
+++ b/maskmypy/masks/__init__.py
@@ -1,4 +1,4 @@
 from .donut import donut
 from .locationswap import locationswap
-from .street import street
+from .street import street, street_k
 from .voronoi import voronoi

--- a/maskmypy/tools.py
+++ b/maskmypy/tools.py
@@ -13,6 +13,36 @@ from pandas.util import hash_pandas_object
 from pyproj.crs.crs import CRS
 
 
+def suppress(gdf, min_k, col: str = "k_anonymity", label: bool = True):
+    """
+    Suppresses points that do not meet a minimum k-anonymity value by displacing them
+    to the mean center of the overall point pattern and (optionally) labelling them.
+
+    Parameters
+    ----------
+    gdf : GeoDataFrame
+        A GeoDataFrame containing point data and a column with k-anonymity values.
+    min_k : int
+        Minimum k-anonymity. Points with a k-anonymity below this value will be suppressed.
+    col : str
+        Name of the column containing k-anonymity values.
+    label : bool
+        If True, adds a "SUPPRESSED" column and labels suppressed points.
+
+    Returns
+    -------
+    gdf
+        A GeoDataFrame containing the result of the suppression
+    """
+    sgdf = gdf.copy()
+    centroid = sgdf.dissolve().centroid[0]
+    sgdf.loc[sgdf[col] < min_k, sgdf.geometry.name] = centroid
+    if label:
+        sgdf.loc[sgdf[col] < min_k, "SUPPRESSED"] = "TRUE"
+        sgdf.loc[sgdf[col] >= min_k, "SUPPRESSED"] = "FALSE"
+    return sgdf
+
+
 def checksum(gdf: GeoDataFrame) -> str:
     """
     Calculate SHA256 checksum of a GeoDataFrame and return the first 8 characters.

--- a/maskmypy/tools.py
+++ b/maskmypy/tools.py
@@ -16,7 +16,7 @@ from pyproj.crs.crs import CRS
 def suppress(gdf, min_k, col: str = "k_anonymity", label: bool = True):
     """
     Suppresses points that do not meet a minimum k-anonymity value by displacing them
-    to the mean center of the overall point pattern and (optionally) labelling them.
+    to the mean center of the overall masked point pattern and (optionally) labelling them.
 
     Parameters
     ----------
@@ -32,7 +32,7 @@ def suppress(gdf, min_k, col: str = "k_anonymity", label: bool = True):
     Returns
     -------
     gdf
-        A GeoDataFrame containing the result of the suppression
+        A GeoDataFrame containing the result of the suppression.
     """
     sgdf = gdf.copy()
     centroid = sgdf.dissolve().centroid[0]

--- a/tests/masks/test_street.py
+++ b/tests/masks/test_street.py
@@ -69,12 +69,12 @@ def test_street_k(points, address):
     target_k = 5
     suppression = 0.80
 
-    masked = street(points, low=1, high=5, max_length=2000)
+    masked = street(points, low=1, high=5, seed=12345)
     masked_k = analysis.k_anonymity(points, masked, address)
     k_sat = analysis.k_satisfaction(masked_k, target_k)
     assert k_sat < suppression
 
-    masked = street_k(points, address, start=1, spread=4, min_k=target_k, suppression=suppression)
+    masked = street_k(points, address, start=1, spread=4, min_k=target_k, suppression=suppression, seed=12345)
     k_sat = analysis.k_satisfaction(masked, target_k)
     assert k_sat >= suppression
     assert len(masked.loc[masked["SUPPRESSED"] == "TRUE", :]) > 1

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -54,19 +54,19 @@ def test_estimate_k_address():
     results1 = analysis._calculate_k(
         sensitive_gdf=sens_gdf, candidate_gdf=mask1_gdf, address_gdf=addr_gdf
     )
-    assert results1.loc[0, "k_anonymity"] == 2
+    assert results1.loc[0, "k_anonymity"] == 3
 
     mask2_gdf = gpd.GeoDataFrame({"geometry": [Point(2, 0)]}, crs="EPSG:32630")
     results2 = analysis._calculate_k(
         sensitive_gdf=sens_gdf, candidate_gdf=mask2_gdf, address_gdf=addr_gdf
     )
-    assert results2.loc[0, "k_anonymity"] == 4
+    assert results2.loc[0, "k_anonymity"] == 5
 
     mask3_gdf = gpd.GeoDataFrame({"geometry": [Point(3, 0)]}, crs="EPSG:32630")
     results3 = analysis._calculate_k(
         sensitive_gdf=sens_gdf, candidate_gdf=mask3_gdf, address_gdf=addr_gdf
     )
-    assert results3.loc[0, "k_anonymity"] == 5
+    assert results3.loc[0, "k_anonymity"] == 6
 
 
 def test_estimate_k_polygon():
@@ -87,16 +87,14 @@ def test_estimate_k_polygon():
     results1 = analysis._estimate_k(
         sensitive_gdf=sens1_gdf, candidate_gdf=mask1_gdf, population_gdf=pop_gdf
     )
-    assert results1.loc[0, "k_anonymity"] == sum(census_poly["pop"]) - 1
+    assert results1.loc[0, "k_anonymity"] == sum(census_poly["pop"])
 
     # uncertainty area only covers part of the 1000 pop area. As pop = 1000, and
     # coverage is bottom right quadrant of a buffer centered on top left corner
-    # of top left quadrant, k should roughly equal ((population * pi * radius)/4) - 1
+    # of top left quadrant, k should roughly equal ((population * pi * radius)/4)
     sens2_gdf = gpd.GeoDataFrame({"geometry": [Point(0, 1)]}, crs="EPSG:32630")
     mask2_gdf = gpd.GeoDataFrame({"geometry": [Point(-1, 1)]}, crs="EPSG:32630")
-    expected_k = (
-        ((mask2_gdf.buffer(mask2_gdf.distance(sens2_gdf)).area * 1000) / 4).apply(floor)
-    ) - 1
+    expected_k = ((mask2_gdf.buffer(mask2_gdf.distance(sens2_gdf)).area * 1000) / 4).apply(floor)
 
     results2 = analysis._estimate_k(
         sensitive_gdf=sens2_gdf, candidate_gdf=mask2_gdf, population_gdf=pop_gdf
@@ -112,7 +110,7 @@ def test_estimate_k_polygon():
     )
 
     area = mask3_gdf.buffer(mask3_gdf.distance(sens3_gdf)).area / 4
-    expected_k = ((1 * area) + (10 * area) + (100 * area) + (1000 * area)).apply(floor) - 1
+    expected_k = ((1 * area) + (10 * area) + (100 * area) + (1000 * area)).apply(floor)
     assert results3.loc[0, "k_anonymity"] == expected_k[0]
 
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -68,6 +68,18 @@ def test_estimate_k_address():
     )
     assert results3.loc[0, "k_anonymity"] == 6
 
+    mask4_gdf = gpd.GeoDataFrame({"geometry": [Point(-1, 0)]}, crs="EPSG:32630")
+    results4 = analysis._calculate_k(
+        sensitive_gdf=sens_gdf, candidate_gdf=mask4_gdf, address_gdf=addr_gdf
+    )
+    assert results4.loc[0, "k_anonymity"] == 2
+
+    sens_gdf = gpd.GeoDataFrame({"geometry": [Point(-7, 0)]}, crs="EPSG:32630")
+    mask5_gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)]}, crs="EPSG:32630")
+    results5 = analysis._calculate_k(
+        sensitive_gdf=sens_gdf, candidate_gdf=mask5_gdf, address_gdf=addr_gdf
+    )
+    assert results5.loc[0, "k_anonymity"] == 8
 
 def test_estimate_k_polygon():
     poly1 = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])


### PR DESCRIPTION
Features:
- **street_k mask**: adds a new mask/wrapper around street masking that incrementally increases the low/high values until a specified percent of points achieve a specified k-anonymity, suppressing the rest. In other words, applies street masking with iteratively greater distances until (for instance) 95% of points achieve at least a k-anonymity of 20, with the failing points being suppressed by being displaced to the mean center of the masked point distribution. 

- **suppression tool**: adds a function (`tools.suppress()`) that suppresses points that do not meet a given spatial k-anonymity threshold by displacing them to the center of the masked point pattern, and optionally marking them as suppressed in a separate column. This can be useful when, for instance, 99% of points are well protected, but the last 1% would require upping masking distances considerably, incurring significant information loss; instead, it may be better to simply suppress them.

Bug Fix & Misc:
- **spatial k-anonymity**: was being under-reported by 1. Fortunately this means that points are actually more protected than reported, rather than less. This is because the masked point was not being included in the equivalence class, which is now fixed. 
- Minor code cleanup & test improvements
